### PR TITLE
Add streaming response support

### DIFF
--- a/chat_bot.py
+++ b/chat_bot.py
@@ -180,14 +180,21 @@ if st.session_state["logged_in"]:
                 temperature=1,
                 max_completion_tokens=6080,
                 top_p=1,
-                stream=False,
+                stream=True,
                 stop=None,
             )
-        
-        if chat_completion.choices:
-            generated_text = chat_completion.choices[0].message.content
-        else:
+
+        generated_text = ""
+        message_placeholder = st.empty()
+        for chunk in chat_completion:
+            if chunk.choices:
+                content = chunk.choices[0].delta.content
+                if content:
+                    generated_text += content
+                    message_placeholder.markdown(generated_text + "▌")
+        if not generated_text:
             generated_text = "Lo siento, no pude generar una respuesta."
+        message_placeholder.markdown(generated_text)
         
         st.session_state["messages"].append({"role": "assistant", "content": generated_text})
         document_ref.set({"messages": st.session_state["messages"]})

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Psycho Bot Rebelde es un chatbot interactivo desarrollado con Streamlit y Fireba
 - Almacenamiento de conversaciones en Firestore.
 - Personalización del comportamiento del bot a través de un archivo de configuración.
 - Interfaz amigable y fácil de usar.
+- Respuestas generadas en streaming para una interacción más fluida.
 
 ## Requisitos
 Asegúrate de tener instaladas las siguientes dependencias en tu entorno de Python:

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,7 @@ Psycho Bot Rebelde es un chatbot interactivo desarrollado con Streamlit y Fireba
 - Almacenamiento de conversaciones en Firestore.
 - Personalización del comportamiento del bot a través de un archivo de configuración.
 - Interfaz amigable y fácil de usar.
+- El contexto de la conversación se limita a las cinco últimas interacciones guardadas en Firebase.
 - Respuestas generadas en streaming para una interacción más fluida.
 
 ## Requisitos


### PR DESCRIPTION
## Summary
- enable token streaming from the Groq API
- show streamed chunks live in Streamlit
- document streaming capability in README

## Testing
- `python -m py_compile chat_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_6841da2704a4832bb2160c0222ab2352